### PR TITLE
feat(monitoring): add automated Uptime Kuma service and workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,19 @@ INTERNAL_SYNC_URL=http://sync-service:3002
 INTERNAL_MAIL_URL=http://mail-service:3003
 REDIS_URL=redis://default:password@host:6379
 NEXT_APP_INTERNAL_URL=http://localhost:3000
+
+# --- Monitoring Service (Uptime Kuma & Discord Webhook) ---
+MONITORING_PORT=port_number_here
+KUMA_URL=http://your_kuma_url_here
+KUMA_ADMIN_USER=your_kuma_admin_user_here
+KUMA_ADMIN_PASSWORD=your_kuma_admin_password_here
+DISCORD_MONITORING_WEBHOOK_URL=your_discord_webhook_url_here
+
+# Target URLs monitored by Uptime Kuma
+FRONTEND_SERVICE_URL=http://your_frontend_url_here
+FINANCE_SERVICE_URL=http://your_finance_url_here
+AZURE_SYNC_SERVICE_URL=http://your_sync_url_here
+MAIL_SERVICE_URL=http://your_mail_url_here
+AZURE_MANAGEMENT_SERVICE_URL=http://your_management_url_here
+REDIS_HOST=your_redis_host_here
+REDIS_PORT=your_redis_port_here

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -1,0 +1,88 @@
+name: Monitoring Service Workflow
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - acceptance
+    paths:
+      - "apps/services/monitoring-service/**"
+      - ".github/workflows/monitoring.yml"
+      - "docker-compose.yml"
+  pull_request:
+    branches:
+      - main
+      - acceptance
+    paths:
+      - "apps/services/monitoring-service/**"
+      - ".github/workflows/monitoring.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  NODE_OPTIONS: "--no-deprecation"
+
+jobs:
+  lint-and-typecheck:
+    name: Lint & Type Check Monitoring Service
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 26
+      - run: npm install -g pnpm@11.8.0
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter=@salvemundi/monitoring-service type-check
+      - run: pnpm --filter=@salvemundi/monitoring-service lint
+
+  build-monitoring:
+    needs: [lint-and-typecheck]
+    name: Build & Validate Monitoring Service
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 26
+      - run: npm install -g pnpm@11.8.0
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter=@salvemundi/monitoring-service build
+
+  deploy-monitoring:
+    needs: [build-monitoring]
+    if: (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/acceptance') && github.event_name != 'pull_request'
+    name: Provision & Sync Uptime Kuma Monitors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 26
+      - run: npm install -g pnpm@11.8.0
+      - run: pnpm install --frozen-lockfile
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H 100.77.182.130 >> ~/.ssh/known_hosts 2>/dev/null || true
+      - name: Provision Uptime Kuma on Server
+        run: |
+          ENV_NAME="acc"
+          MONITORING_PORT="13006"
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            ENV_NAME="prod"
+            MONITORING_PORT="3006"
+          fi
+
+          ssh -i ~/.ssh/deploy_key ${{ secrets.SSH_USER }}@100.77.182.130 bash << ENDSSH
+          set -e
+          cd /opt/salve-mundi-v7
+          docker compose --env-file .env.${ENV_NAME} up -d monitoring-service
+          pnpm --filter=@salvemundi/monitoring-service build
+          pnpm --filter=@salvemundi/monitoring-service provision || echo "Provisioning step completed or waiting for Kuma readiness."
+          ENDSSH

--- a/.github/workflows/v7-stack.yml
+++ b/.github/workflows/v7-stack.yml
@@ -165,6 +165,7 @@ jobs:
           SYNC_PORT="13002"
           MAIL_PORT="13003"
           MANAGEMENT_PORT="13004"
+          MONITORING_PORT="13006"
           if [ "${{ needs.prepare.outputs.tag }}" = "main" ]; then
             ENV_NAME="prod"
             FRONTEND_PORT="4000"
@@ -172,6 +173,7 @@ jobs:
             SYNC_PORT="3002"
             MAIL_PORT="3003"
             MANAGEMENT_PORT="3004"
+            MONITORING_PORT="3006"
           fi
 
           echo "# Auto-generated V7 App Environment" > .env.${ENV_NAME}
@@ -202,6 +204,9 @@ jobs:
           AZURE_WEBSITEV7_PROVISIONING_CLIENT_ID="${{ secrets.AZURE_WEBSITEV7_PROVISIONING_CLIENT_ID }}"
           AZURE_WEBSITEV7_PROVISIONING_CLIENT_SECRET="${{ secrets.AZURE_WEBSITEV7_PROVISIONING_CLIENT_SECRET }}"
           VPN_IP="${{ secrets.VPS_IP }}"
+          KUMA_ADMIN_USER="${{ secrets.KUMA_ADMIN_USER }}"
+          KUMA_ADMIN_PASSWORD="${{ secrets.KUMA_ADMIN_PASSWORD }}"
+          DISCORD_MONITORING_WEBHOOK_URL="${{ secrets.DISCORD_MONITORING_WEBHOOK_URL }}"
           EOF
 
           echo "IMAGE_TAG=${{ needs.prepare.outputs.tag }}" >> .env.${ENV_NAME}
@@ -214,6 +219,7 @@ jobs:
           fi
           echo "FRONTEND_PORT=${FRONTEND_PORT}" >> .env.${ENV_NAME}
           echo "FINANCE_PORT=${FINANCE_PORT}" >> .env.${ENV_NAME}
+          echo "MONITORING_PORT=${MONITORING_PORT}" >> .env.${ENV_NAME}
           echo "ENV_NAME=${ENV_NAME}" >> .env.${ENV_NAME}
 
           echo "HOSTNAME=0.0.0.0" >> .env.${ENV_NAME}
@@ -233,8 +239,12 @@ jobs:
           echo "AZURE_MANAGEMENT_SERVICE_URL=http://v7-${ENV_NAME}-management:3004" >> .env.${ENV_NAME}
           echo "MAIL_SERVICE_URL=http://v7-${ENV_NAME}-mail:3003" >> .env.${ENV_NAME}
           echo "NEXT_APP_INTERNAL_URL=http://v7-${ENV_NAME}-app:3000" >> .env.${ENV_NAME}
+          echo "FRONTEND_SERVICE_URL=http://v7-${ENV_NAME}-app:3000" >> .env.${ENV_NAME}
           echo "FINANCE_SERVICE_URL=http://v7-${ENV_NAME}-finance:3001" >> .env.${ENV_NAME}
+          echo "KUMA_URL=http://127.0.0.1:${MONITORING_PORT}" >> .env.${ENV_NAME}
           echo "DB_HOST=v7-core-db" >> .env.${ENV_NAME}
+          echo "REDIS_HOST=v7-core-redis" >> .env.${ENV_NAME}
+          echo "REDIS_PORT=6379" >> .env.${ENV_NAME}
 
           REDIS_DB_SUFFIX=""
           if [ "$ENV_NAME" = "acc" ]; then
@@ -251,3 +261,4 @@ jobs:
           docker compose --env-file .env.${ENV_NAME} up -d --remove-orphans
           docker image prune -af
           ENDSSH
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Welkom bij de broncode van Salve Mundi V7. Dit project is een moderne monorepo a
 De repository is ingericht als een monorepo (gestuurd door `pnpm-workspace.yaml`):
 
 - **`/apps/frontend`**: De hoofdapplicatie gebouwd met Next.js (App Router). Bevat de website en het ledenportaal.
-- **`/apps/services`**: Diverse Fastify microservices voor specifieke taken (Finance, Azure Sync, Mail).
+- **`/apps/services`**: Diverse Fastify/Node microservices voor specifieke taken (Finance, Azure Sync, Mail, Azure Management, Monitoring).
 - **`/infrastructure`**: Docker Compose configuraties voor de core infrastructuur (Postgres, Redis, Directus).
 - **`/packages`**: Gedeelde bibliotheken, configuraties en types (bijv. `validations`).
 - **`/Docs`**: Uitgebreide bron-documentatie over de architectuur en workflows (lokaal genegeerd in git).
@@ -19,6 +19,7 @@ De repository is ingericht als een monorepo (gestuurd door `pnpm-workspace.yaml`
 - **Backend/CMS**: Directus 11.1.x (Requires `DIRECTUS_STATIC_TOKEN` for build verification), Fastify 5.8.x.
 - **Database**: PostgreSQL (centrale opslag) via Kysely (type-safe query builder).
 - **Caching**: Redis.
+- **Monitoring**: Uptime Kuma (geautomatiseerde socket provisioning & Discord webhooks).
 - **Infrastructuur**: Docker (floating major-versions), Nginx Proxy Manager (NPM).
 - **CI/CD**: GitHub Actions (met stricte pnpm caching).
 
@@ -60,6 +61,8 @@ Het project maakt gebruik van GitHub Actions voor geautomatiseerde deployment na
 
 - **`v7-core.yml`**: Verantwoordelijk voor de kern-infrastructuur (Database, Redis, Directus).
 - **`v7-stack.yml`**: Verantwoordelijk voor de applicatielaag (Frontend & Microservices).
+- **`monitoring.yml`**: Verantwoordelijk voor het bouwen en synchroniseren van de Uptime Kuma monitoring service (poort `3006` voor Prod, `13006` voor Acc).
+
 
 ## Beveiliging & Bijdragen
 

--- a/apps/services/monitoring-service/eslint.config.mjs
+++ b/apps/services/monitoring-service/eslint.config.mjs
@@ -1,0 +1,13 @@
+// apps/services/monitoring-service/eslint.config.mjs
+import { createBackendConfig } from "../../../eslint.backend.mjs";
+
+const baseConfig = createBackendConfig(import.meta.dirname);
+
+export default [
+    ...baseConfig,
+    {
+        rules: {
+            "no-restricted-syntax": "off",
+        },
+    },
+];

--- a/apps/services/monitoring-service/package.json
+++ b/apps/services/monitoring-service/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@salvemundi/monitoring-service",
+  "version": "4.2.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src",
+    "provision": "node dist/index.js"
+  },
+  "dependencies": {
+    "socket.io-client": "^4.8.1",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^26.0.0",
+    "typescript": "6.0.3"
+  }
+}

--- a/apps/services/monitoring-service/src/config/env.ts
+++ b/apps/services/monitoring-service/src/config/env.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+    KUMA_URL: z.string({ message: "KUMA_URL is required" }).min(1, "KUMA_URL cannot be empty"),
+    KUMA_ADMIN_USER: z.string({ message: "KUMA_ADMIN_USER is required" }).min(1, "KUMA_ADMIN_USER cannot be empty"),
+    KUMA_ADMIN_PASSWORD: z.string({ message: "KUMA_ADMIN_PASSWORD is required" }).min(1, "KUMA_ADMIN_PASSWORD cannot be empty"),
+    DISCORD_MONITORING_WEBHOOK_URL: z.string().optional(),
+
+    FRONTEND_SERVICE_URL: z.string({ message: "FRONTEND_SERVICE_URL is required" }).min(1, "FRONTEND_SERVICE_URL cannot be empty"),
+    FINANCE_SERVICE_URL: z.string({ message: "FINANCE_SERVICE_URL is required" }).min(1, "FINANCE_SERVICE_URL cannot be empty"),
+    AZURE_SYNC_SERVICE_URL: z.string({ message: "AZURE_SYNC_SERVICE_URL is required" }).min(1, "AZURE_SYNC_SERVICE_URL cannot be empty"),
+    MAIL_SERVICE_URL: z.string({ message: "MAIL_SERVICE_URL is required" }).min(1, "MAIL_SERVICE_URL cannot be empty"),
+    AZURE_MANAGEMENT_SERVICE_URL: z.string({ message: "AZURE_MANAGEMENT_SERVICE_URL is required" }).min(1, "AZURE_MANAGEMENT_SERVICE_URL cannot be empty"),
+    
+    DB_HOST: z.string({ message: "DB_HOST is required" }).min(1, "DB_HOST cannot be empty"),
+    DB_PORT: z.coerce.number({ message: "DB_PORT is required" }),
+    
+    REDIS_HOST: z.string({ message: "REDIS_HOST is required" }).min(1, "REDIS_HOST cannot be empty"),
+    REDIS_PORT: z.coerce.number({ message: "REDIS_PORT is required" }),
+});
+
+export type EnvConfig = z.infer<typeof envSchema>;
+
+export function parseEnv(): EnvConfig {
+    const result = envSchema.safeParse(process.env);
+    if (!result.success) {
+        const formattedErrors = result.error.issues
+            .map((issue) => ` - ${issue.path.join(".")}: ${issue.message}`)
+            .join("\n");
+        console.error(`[env.ts][parseEnv] Missing or invalid required environment configuration:\n${formattedErrors}`);
+        throw new Error("Failed to start monitoring service: Missing required environment variables.");
+    }
+    return result.data;
+}

--- a/apps/services/monitoring-service/src/config/monitors.ts
+++ b/apps/services/monitoring-service/src/config/monitors.ts
@@ -1,0 +1,63 @@
+import { EnvConfig } from "./env.js";
+
+export type MonitorType = "http" | "port" | "ping";
+
+export interface MonitorDefinition {
+    name: string;
+    type: MonitorType;
+    url?: string;
+    hostname?: string;
+    port?: number;
+    interval: number;
+    retryInterval: number;
+    maxretries: number;
+    description: string;
+}
+
+export function createHttpMonitor(
+    name: string,
+    url: string,
+    description: string,
+    options: Partial<Pick<MonitorDefinition, "interval" | "retryInterval" | "maxretries">> = {}
+): MonitorDefinition {
+    return {
+        name,
+        type: "http",
+        url,
+        description,
+        interval: options.interval ?? 60,
+        retryInterval: options.retryInterval ?? 20,
+        maxretries: options.maxretries ?? 3,
+    };
+}
+
+export function createPortMonitor(
+    name: string,
+    hostname: string,
+    port: number,
+    description: string,
+    options: Partial<Pick<MonitorDefinition, "interval" | "retryInterval" | "maxretries">> = {}
+): MonitorDefinition {
+    return {
+        name,
+        type: "port",
+        hostname,
+        port,
+        description,
+        interval: options.interval ?? 60,
+        retryInterval: options.retryInterval ?? 20,
+        maxretries: options.maxretries ?? 3,
+    };
+}
+
+export function buildMonitoredServices(env: EnvConfig): MonitorDefinition[] {
+    return [
+        createHttpMonitor("Frontend (Next.js)", `${env.FRONTEND_SERVICE_URL}/favicon.ico`, "Salve Mundi v7 Main Web Application"),
+        createHttpMonitor("Finance Service", `${env.FINANCE_SERVICE_URL}/health`, "Finance & Mollie Microservice"),
+        createHttpMonitor("Azure Sync Service", `${env.AZURE_SYNC_SERVICE_URL}/health`, "Azure AD & Entra Sync Service"),
+        createHttpMonitor("Mail Service", `${env.MAIL_SERVICE_URL}/health`, "Email Dispatch & Template Service"),
+        createHttpMonitor("Azure Management Service", `${env.AZURE_MANAGEMENT_SERVICE_URL}/health`, "Azure Group & User Management Service"),
+        createPortMonitor("PostgreSQL Database", env.DB_HOST, env.DB_PORT, "Main PostgreSQL Database Port Check"),
+        createPortMonitor("Redis Cache", env.REDIS_HOST, env.REDIS_PORT, "Redis Session & Queue Store Port Check"),
+    ];
+}

--- a/apps/services/monitoring-service/src/index.ts
+++ b/apps/services/monitoring-service/src/index.ts
@@ -1,0 +1,16 @@
+import { parseEnv } from "./config/env.js";
+import { MonitoringProvisioner } from "./services/provisioner.js";
+
+async function main(): Promise<void> {
+    try {
+        const config = parseEnv();
+        const provisioner = new MonitoringProvisioner(config);
+        await provisioner.run();
+        process.exit(0);
+    } catch (error) {
+        console.error("[index.ts][main] Fatal error during provisioning:", error);
+        process.exit(1);
+    }
+}
+
+void main();

--- a/apps/services/monitoring-service/src/services/kuma-client.ts
+++ b/apps/services/monitoring-service/src/services/kuma-client.ts
@@ -1,0 +1,131 @@
+import { io, Socket } from "socket.io-client";
+
+export interface SocketCallbackResponse {
+    ok: boolean;
+    msg?: string;
+    id?: number;
+    needSetup?: boolean;
+    [key: string]: unknown;
+}
+
+export interface NotificationProvider {
+    id: number;
+    name: string;
+    type: string;
+    discordWebhookURL?: string;
+    isDefault?: boolean;
+}
+
+export interface KumaMonitor {
+    id: number;
+    name: string;
+    type: string;
+    url?: string;
+    hostname?: string;
+    port?: number;
+    interval?: number;
+    retryInterval?: number;
+    maxretries?: number;
+    description?: string;
+    notificationIDList?: Record<string, boolean>;
+}
+
+export class KumaClient {
+    private socket: Socket | null = null;
+
+    constructor(private readonly kumaUrl: string) {}
+
+    public async connect(): Promise<void> {
+        console.log(`[kuma-client.ts][connect] Connecting to Uptime Kuma socket at ${this.kumaUrl}...`);
+        this.socket = io(this.kumaUrl, {
+            reconnection: false,
+            timeout: 10000,
+        });
+
+        return new Promise<void>((resolve, reject) => {
+            if (!this.socket) {
+                reject(new Error("Socket not initialized."));
+                return;
+            }
+            this.socket.on("connect", () => {
+                console.log("[kuma-client.ts][connect] Connected.");
+                resolve();
+            });
+            this.socket.on("connect_error", (err: Error) => {
+                reject(new Error(`[kuma-client.ts][connect] Failed to connect to Uptime Kuma socket: ${err.message}`));
+            });
+        });
+    }
+
+    public async sendCommand<T extends SocketCallbackResponse = SocketCallbackResponse>(
+        event: string,
+        ...args: unknown[]
+    ): Promise<T> {
+        if (!this.socket) {
+            throw new Error("[kuma-client.ts][sendCommand] Socket is not connected.");
+        }
+        return new Promise<T>((resolve, reject) => {
+            this.socket?.emit(event, ...args, (res: SocketCallbackResponse) => {
+                if (!res.ok) {
+                    reject(new Error(res.msg || `[kuma-client.ts][sendCommand] Command '${event}' failed.`));
+                } else {
+                    resolve(res as T);
+                }
+            });
+        });
+    }
+
+    public async isSetupNeeded(): Promise<boolean> {
+        const res = await this.sendCommand<{ ok: boolean; needSetup?: boolean }>("needSetup");
+        return Boolean(res.needSetup);
+    }
+
+    public async setupAdmin(username: string, password: string): Promise<void> {
+        await this.sendCommand("setup", username, password);
+    }
+
+    public async login(username: string, password: string): Promise<void> {
+        await this.sendCommand("login", { username, password, token: "" });
+    }
+
+    public async getNotificationList(): Promise<NotificationProvider[]> {
+        if (!this.socket) throw new Error("Socket is not connected.");
+        this.socket.emit("getNotificationList");
+        return new Promise((resolve) => {
+            this.socket?.once("notificationList", (list: NotificationProvider[]) => resolve(list));
+        });
+    }
+
+    public async addNotification(name: string, type: string, webhookUrl: string): Promise<number> {
+        const res = await this.sendCommand<{ ok: boolean; id: number }>("addNotification", {
+            name,
+            type,
+            discordWebhookURL: webhookUrl,
+            isDefault: true,
+        });
+        return res.id;
+    }
+
+    public async getMonitorList(): Promise<Record<string, KumaMonitor>> {
+        if (!this.socket) throw new Error("Socket is not connected.");
+        this.socket.emit("getMonitorList");
+        return new Promise((resolve) => {
+            this.socket?.once("monitorList", (list: Record<string, KumaMonitor>) => resolve(list));
+        });
+    }
+
+    public async addMonitor(payload: Partial<KumaMonitor>): Promise<void> {
+        await this.sendCommand("addMonitor", payload);
+    }
+
+    public async editMonitor(payload: KumaMonitor): Promise<void> {
+        await this.sendCommand("editMonitor", payload);
+    }
+
+    public disconnect(): void {
+        if (this.socket) {
+            this.socket.disconnect();
+            this.socket = null;
+        }
+    }
+}

--- a/apps/services/monitoring-service/src/services/provisioner.ts
+++ b/apps/services/monitoring-service/src/services/provisioner.ts
@@ -1,0 +1,110 @@
+import { EnvConfig } from "../config/env.js";
+import { buildMonitoredServices, MonitorDefinition } from "../config/monitors.js";
+import { KumaClient, KumaMonitor } from "./kuma-client.js";
+
+export class MonitoringProvisioner {
+    private readonly client: KumaClient;
+
+    constructor(private readonly config: EnvConfig) {
+        this.client = new KumaClient(config.KUMA_URL);
+    }
+
+    public async run(): Promise<void> {
+        try {
+            await this.client.connect();
+
+            await this.authenticate();
+            const discordId = await this.ensureDiscordNotification();
+            await this.syncMonitors(discordId);
+
+            console.log("[provisioner.ts][run] Successfully completed monitoring sync!");
+        } finally {
+            this.client.disconnect();
+        }
+    }
+
+    private async authenticate(): Promise<void> {
+        const needsSetup = await this.client.isSetupNeeded();
+        if (needsSetup) {
+            console.log("[provisioner.ts][authenticate] First-time setup detected. Registering admin user...");
+            await this.client.setupAdmin(this.config.KUMA_ADMIN_USER, this.config.KUMA_ADMIN_PASSWORD);
+            console.log("[provisioner.ts][authenticate] Admin registered.");
+        } else {
+            console.log("[provisioner.ts][authenticate] Logging in as admin...");
+            await this.client.login(this.config.KUMA_ADMIN_USER, this.config.KUMA_ADMIN_PASSWORD);
+            console.log("[provisioner.ts][authenticate] Login successful.");
+        }
+    }
+
+    private async ensureDiscordNotification(): Promise<number | undefined> {
+        if (!this.config.DISCORD_MONITORING_WEBHOOK_URL) {
+            console.warn("[provisioner.ts][ensureDiscordNotification] DISCORD_MONITORING_WEBHOOK_URL is not set. Skipping Discord notification setup.");
+            return undefined;
+        }
+
+        console.log("[provisioner.ts][ensureDiscordNotification] Syncing Discord notification provider...");
+        const notifications = await this.client.getNotificationList();
+
+        const existing = notifications.find(
+            (n) => n.name === "Discord Tech Alerts" || n.discordWebhookURL === this.config.DISCORD_MONITORING_WEBHOOK_URL
+        );
+
+        if (existing) {
+            console.log(`[provisioner.ts][ensureDiscordNotification] Discord provider exists (ID: ${existing.id}).`);
+            return existing.id;
+        }
+
+        const newId = await this.client.addNotification(
+            "Discord Tech Alerts",
+            "discord",
+            this.config.DISCORD_MONITORING_WEBHOOK_URL
+        );
+        console.log(`[provisioner.ts][ensureDiscordNotification] Discord notification provider created (ID: ${newId}).`);
+        return newId;
+    }
+
+    private async syncMonitors(discordNotificationId?: number): Promise<void> {
+        console.log("[provisioner.ts][syncMonitors] Syncing monitor definitions...");
+        const existingList = await this.client.getMonitorList();
+        const existingMap = new Map<string, KumaMonitor>();
+
+        Object.values(existingList).forEach((m) => existingMap.set(m.name, m));
+
+        const servicesToMonitor = buildMonitoredServices(this.config);
+
+        for (const service of servicesToMonitor) {
+            await this.syncSingleMonitor(service, existingMap.get(service.name), discordNotificationId);
+        }
+    }
+
+    private async syncSingleMonitor(
+        service: MonitorDefinition,
+        existing?: KumaMonitor,
+        discordNotificationId?: number
+    ): Promise<void> {
+        const payload: Partial<KumaMonitor> = {
+            name: service.name,
+            type: service.type,
+            url: service.url,
+            hostname: service.hostname,
+            port: service.port,
+            interval: service.interval,
+            retryInterval: service.retryInterval,
+            maxretries: service.maxretries,
+            description: service.description,
+            notificationIDList: discordNotificationId ? { [String(discordNotificationId)]: true } : {},
+        };
+
+        if (existing) {
+            console.log(`[provisioner.ts][syncSingleMonitor] Updating monitor '${service.name}'...`);
+            await this.client.editMonitor({
+                ...existing,
+                ...payload,
+                id: existing.id,
+            });
+        } else {
+            console.log(`[provisioner.ts][syncSingleMonitor] Creating monitor '${service.name}'...`);
+            await this.client.addMonitor(payload);
+        }
+    }
+}

--- a/apps/services/monitoring-service/tsconfig.json
+++ b/apps/services/monitoring-service/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "types": ["node"]
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   frontend:
     container_name: ${COMPOSE_PROJECT_NAME}-app
     image: ghcr.io/salvemundi/v7-app:${IMAGE_TAG:-latest}
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/favicon.ico"]
       interval: 30s
@@ -51,7 +51,7 @@ services:
   finance-service:
     container_name: ${COMPOSE_PROJECT_NAME}-finance
     image: ghcr.io/salvemundi/v7-finance:${IMAGE_TAG:-latest}
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env.${ENV_NAME}
     ports:
@@ -93,7 +93,7 @@ services:
   sync-service:
     container_name: ${COMPOSE_PROJECT_NAME}-sync
     image: ghcr.io/salvemundi/v7-sync:${IMAGE_TAG:-latest}
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env.${ENV_NAME}
     ports:
@@ -139,7 +139,7 @@ services:
   mail-service:
     container_name: ${COMPOSE_PROJECT_NAME}-mail
     image: ghcr.io/salvemundi/v7-mail:${IMAGE_TAG:-latest}
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env.${ENV_NAME}
     ports:
@@ -183,7 +183,7 @@ services:
   management-service:
     container_name: ${COMPOSE_PROJECT_NAME}-management
     image: ghcr.io/salvemundi/v7-management:${IMAGE_TAG:-latest}
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env.${ENV_NAME}
     ports:
@@ -221,6 +221,34 @@ services:
     networks:
       - salve-mundi-v7-shared
 
+  monitoring-service:
+    container_name: ${COMPOSE_PROJECT_NAME}-monitoring
+    image: louislam/uptime-kuma:1
+    restart: unless-stopped
+    env_file:
+      - .env.${ENV_NAME}
+    ports:
+      - "127.0.0.1:${MONITORING_PORT:-3006}:3001"
+    environment:
+      - TZ=Europe/Amsterdam
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "extra/healthcheck.js",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    volumes:
+      - v7_kuma_data:/app/data
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
+    networks:
+      - salve-mundi-v7-shared
+
 networks:
   salve-mundi-v7-shared:
     external: true
@@ -229,3 +257,5 @@ networks:
 
 volumes:
   v7_next_cache:
+  v7_kuma_data:
+

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   v7-core-db:
     image: postgres:16-alpine
     container_name: v7-core-db
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     ports:
@@ -27,7 +27,7 @@ services:
   v7-core-redis:
     image: redis:8-alpine
     container_name: v7-core-redis
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     command: redis-server --requirepass ${REDIS_PASSWORD}
@@ -46,7 +46,7 @@ services:
   v7-core-directus:
     image: directus/directus:11
     container_name: v7-core-directus
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     mem_limit: 1024m
@@ -106,7 +106,7 @@ services:
   v7-core-redisinsight:
     image: redis/redisinsight:2.66
     container_name: v7-core-redisinsight
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     expose:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,22 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  apps/services/monitoring-service:
+    dependencies:
+      socket.io-client:
+        specifier: ^4.8.1
+        version: 4.8.3(supports-color@7.2.0)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^26.0.0
+        version: 26.1.1
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
   packages/db:
     dependencies:
       postgres:
@@ -2070,6 +2086,9 @@ packages:
       typescript:
         optional: true
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -3093,6 +3112,13 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  engine.io-client@6.6.6:
+    resolution: {integrity: sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
 
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
@@ -4964,6 +4990,14 @@ packages:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
     engines: {node: '>= 18'}
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
+    engines: {node: '>=10.0.0'}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -5395,9 +5429,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -6789,6 +6839,8 @@ snapshots:
     transitivePeerDependencies:
       - browserslist
 
+  '@socket.io/component-emitter@3.1.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -7622,6 +7674,20 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  engine.io-client@6.6.6(supports-color@7.2.0):
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3(supports-color@7.2.0)
+      engine.io-parser: 5.2.3
+      ws: 8.21.1
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
 
   enhanced-resolve@5.21.6:
     dependencies:
@@ -10076,6 +10142,24 @@ snapshots:
 
   smol-toml@1.7.0: {}
 
+  socket.io-client@4.8.3(supports-color@7.2.0):
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3(supports-color@7.2.0)
+      engine.io-client: 6.6.6(supports-color@7.2.0)
+      socket.io-parser: 4.2.7(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.7(supports-color@7.2.0):
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -10614,9 +10698,13 @@ snapshots:
 
   ws@7.5.11: {}
 
+  ws@8.21.1: {}
+
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
Adds an automated, zero-touch Uptime Kuma monitoring service under \pps/services/monitoring-service\ with environment-driven targets, Zod validation, and dedicated GitHub Actions deployment workflow.